### PR TITLE
Changes StarWars to Star Wars

### DIFF
--- a/vote/app.py
+++ b/vote/app.py
@@ -7,7 +7,7 @@ import json
 import logging
 
 option_a = os.getenv('OPTION_A', "Star Trek")
-option_b = os.getenv('OPTION_B', "StarWars")
+option_b = os.getenv('OPTION_B', "Star Wars")
 hostname = socket.gethostname()
 
 app = Flask(__name__)


### PR DESCRIPTION
Fixes #12343423: Inconsistencies in movie title names

This should fix instances where Star Wars becomes StarWars in the Voting App (`/vote/app.py`)