### PR TITLE
Pin docker-ce

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: gitpod/workspace-full
+image: gitpod/workspace-full:2024-04-16-12-16-24
 
 tasks:
   - name: Build


### PR DESCRIPTION
This temporarily works around the incident by using a pinned version of workspace-full. 

For demos, unless you need a "bleeding edge" image, this is probably for the best.